### PR TITLE
fix(index-react-js): fix typo in widget import

### DIFF
--- a/template-react/src/widget/index.js
+++ b/template-react/src/widget/index.js
@@ -1,4 +1,4 @@
-import Widget from "./widget";
+import Widget from "./Widget";
 import WidgetGlobalSettings from "./WidgetGlobalSettings";
 import WidgetSettings from "./WidgetSettings";
 


### PR DESCRIPTION
I found this typo when I try to start a new React Js widget 