### PR TITLE
docs(api): point to the latest API docs

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -7,4 +7,4 @@ has_children: false
 
 # LumApps API
 
-The LumApps API documentation is available [here](https://api.lumapps.com/docs/start) 
+The LumApps API documentation is available [here](https://apiv1.lumapps.com) 


### PR DESCRIPTION
Up to date API v1 docs are hosted on apiv1.lumapps.com, not
api.lumapps.com anymore.