### PR TITLE
chore: ignore node_modules

### DIFF
--- a/template-widget-extension/.gitignore
+++ b/template-widget-extension/.gitignore
@@ -25,3 +25,5 @@ yarn-error.log*
 
 *.lum
 build/
+
+node_modules


### PR DESCRIPTION
usually the node_modules folder includes only dependencies - I am proposing to ignore it in order to avoid unfortunate includes in the target repository